### PR TITLE
D3D12 support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(HelloDiligentXr
 		igraphicsbinding.h
 		graphicsbinding_d3d11.cpp
 		graphicsbinding_d3d11.h
+		graphicsbinding_d3d12.cpp
+		graphicsbinding_d3d12.h
 )
 
 target_compile_options(HelloDiligentXr PRIVATE -DUNICODE -DENGINE_DLL)

--- a/src/graphicsbinding_d3d11.cpp
+++ b/src/graphicsbinding_d3d11.cpp
@@ -3,7 +3,6 @@
 #include <d3d11.h>
 #	define XR_USE_GRAPHICS_API_D3D11
 #include "Graphics/GraphicsEngineD3D11/interface/RenderDeviceD3D11.h"
-#endif
 
 #include <openxr/openxr_platform.h>
 
@@ -11,37 +10,12 @@
 
 using namespace Diligent;
 
-#if D3D11_SUPPORTED || D3D12_SUPPORTED
-#include <wrl/client.h>
-
-UINT GetAdapterIndexFromLuid( LUID adapterId )
-{
-	// Create the DXGI factory.
-	Microsoft::WRL::ComPtr<IDXGIFactory1> dxgiFactory;
-	if ( FAILED( CreateDXGIFactory1( __uuidof( IDXGIFactory1 ), reinterpret_cast<void**>( dxgiFactory.ReleaseAndGetAddressOf() ) ) ) )
-		return 0;
-
-	for ( UINT adapterIndex = 0;; adapterIndex++ )
-	{
-		// EnumAdapters1 will fail with DXGI_ERROR_NOT_FOUND when there are no more adapters to enumerate.
-		Microsoft::WRL::ComPtr<IDXGIAdapter1> dxgiAdapter;
-		if ( FAILED( dxgiFactory->EnumAdapters1( adapterIndex, dxgiAdapter.ReleaseAndGetAddressOf() ) ) )
-			break;
-
-		DXGI_ADAPTER_DESC1 adapterDesc;
-		if ( FAILED( dxgiAdapter->GetDesc1( &adapterDesc ) ) )
-			continue;
-		if ( memcmp( &adapterDesc.AdapterLuid, &adapterId, sizeof( adapterId ) ) == 0 ) {
-			return adapterIndex;
-		}
-	}
-	return 0;
-}
-#endif
-
 GraphicsBinding_D3D11::~GraphicsBinding_D3D11()
 {
-	delete m_d3d11Binding;
+	if (m_d3d11Binding)
+	{
+		delete m_d3d11Binding;
+	}
 }
 
 
@@ -135,4 +109,32 @@ std::vector< RefCntAutoPtr<ITexture> > GraphicsBinding_D3D11::ReadImagesFromSwap
 
 	return textures;
 }
+#endif
 
+#if D3D11_SUPPORTED || D3D12_SUPPORTED
+#include <wrl/client.h>
+
+UINT GetAdapterIndexFromLuid( LUID adapterId )
+{
+	// Create the DXGI factory.
+	Microsoft::WRL::ComPtr<IDXGIFactory1> dxgiFactory;
+	if ( FAILED( CreateDXGIFactory1( __uuidof( IDXGIFactory1 ), reinterpret_cast<void**>( dxgiFactory.ReleaseAndGetAddressOf() ) ) ) )
+		return 0;
+
+	for ( UINT adapterIndex = 0;; adapterIndex++ )
+	{
+		// EnumAdapters1 will fail with DXGI_ERROR_NOT_FOUND when there are no more adapters to enumerate.
+		Microsoft::WRL::ComPtr<IDXGIAdapter1> dxgiAdapter;
+		if ( FAILED( dxgiFactory->EnumAdapters1( adapterIndex, dxgiAdapter.ReleaseAndGetAddressOf() ) ) )
+			break;
+
+		DXGI_ADAPTER_DESC1 adapterDesc;
+		if ( FAILED( dxgiAdapter->GetDesc1( &adapterDesc ) ) )
+			continue;
+		if ( memcmp( &adapterDesc.AdapterLuid, &adapterId, sizeof( adapterId ) ) == 0 ) {
+			return adapterIndex;
+		}
+	}
+	return 0;
+}
+#endif

--- a/src/graphicsbinding_d3d12.cpp
+++ b/src/graphicsbinding_d3d12.cpp
@@ -1,0 +1,122 @@
+#if D3D12_SUPPORTED
+#include <dxgi.h>
+#include <d3d12.h>
+#	define XR_USE_GRAPHICS_API_D3D12
+#include "Graphics/GraphicsEngineD3D12/interface/RenderDeviceD3D12.h"
+#include "Graphics/GraphicsEngineD3D12/interface/DeviceContextD3D12.h"
+
+#include <openxr/openxr_platform.h>
+
+#include "graphicsbinding_d3d11.h" // For GetAdapterIndexFromLuid
+#include "graphicsbinding_d3d12.h"
+
+using namespace Diligent;
+
+#include <wrl/client.h>
+
+GraphicsBinding_D3D12::~GraphicsBinding_D3D12()
+{
+	if (m_d3d12Binding)
+	{
+		delete m_d3d12Binding;
+	}
+}
+
+
+std::vector<std::string> GraphicsBinding_D3D12::GetXrExtensions()
+{
+	return { XR_KHR_D3D12_ENABLE_EXTENSION_NAME };
+}
+
+
+XrResult GraphicsBinding_D3D12::CreateDevice( XrInstance instance, XrSystemId systemId )
+{
+	m_instance = instance;
+	m_systemId = systemId;
+
+#	if ENGINE_DLL
+	// Load the dll and import GetEngineFactoryD3D12() function
+	auto* GetEngineFactoryD3D12 = LoadGraphicsEngineD3D12();
+#	endif
+	auto* pFactoryD3D12 = GetEngineFactoryD3D12();
+	m_pEngineFactory = pFactoryD3D12;
+
+	FETCH_AND_DEFINE_XR_FUNCTION( m_instance, xrGetD3D12GraphicsRequirementsKHR );
+	XrGraphicsRequirementsD3D12KHR graphicsRequirements = { XR_TYPE_GRAPHICS_REQUIREMENTS_D3D12_KHR };
+	XrResult res = xrGetD3D12GraphicsRequirementsKHR( m_instance, m_systemId, &graphicsRequirements );
+	if ( XR_FAILED( res ) )
+	{
+		return res;
+	}
+
+	EngineD3D12CreateInfo EngineCI;
+	EngineCI.AdapterId = GetAdapterIndexFromLuid( graphicsRequirements.adapterLuid );
+	EngineCI.GraphicsAPIVersion = Version { 11, 0 };
+	pFactoryD3D12->CreateDeviceAndContextsD3D12( EngineCI, &m_pDevice, &m_pImmediateContext );
+
+	m_d3d12Binding = new XrGraphicsBindingD3D12KHR( { XR_TYPE_GRAPHICS_BINDING_D3D12_KHR } );
+	m_d3d12Binding->device = GetD3D12Device()->GetD3D12Device();
+
+	IDeviceContextD3D12* d3d12DeviceContext = (IDeviceContextD3D12*)GetImmediateContext();
+	ICommandQueueD3D12* d3d12CommandQueue = (ICommandQueueD3D12*)d3d12DeviceContext->LockCommandQueue();
+	m_d3d12Binding->queue = d3d12CommandQueue->GetD3D12CommandQueue();
+	d3d12DeviceContext->UnlockCommandQueue();
+
+	return XR_SUCCESS;
+}
+
+
+Diligent::IEngineFactory* GraphicsBinding_D3D12::GetEngineFactory()
+{
+	return m_pEngineFactory.RawPtr();
+}
+
+std::vector<int64_t> GraphicsBinding_D3D12::GetRequestedColorFormats()
+{
+	return
+	{
+		DXGI_FORMAT_R16G16B16A16_FLOAT,
+		DXGI_FORMAT_R8G8B8A8_UNORM_SRGB
+	};
+}
+
+std::vector<int64_t> GraphicsBinding_D3D12::GetRequestedDepthFormats()
+{
+	return 
+	{
+		DXGI_FORMAT_D32_FLOAT,
+		DXGI_FORMAT_D16_UNORM,
+	};
+}
+
+
+void* GraphicsBinding_D3D12::GetSessionBinding()
+{
+	return m_d3d12Binding;
+}
+
+std::vector< RefCntAutoPtr<ITexture> > GraphicsBinding_D3D12::ReadImagesFromSwapchain( XrSwapchain swapchain )
+{
+	std::vector< RefCntAutoPtr< ITexture > > textures;
+
+	uint32_t imageCount;
+	if ( XR_FAILED( xrEnumerateSwapchainImages( swapchain, 0, &imageCount, nullptr ) ) )
+		return {};
+
+	std::vector< XrSwapchainImageD3D12KHR > images;
+	images.resize( imageCount, { XR_TYPE_SWAPCHAIN_IMAGE_D3D12_KHR } );
+	if ( XR_FAILED( xrEnumerateSwapchainImages( swapchain, 
+		imageCount, &imageCount, (XrSwapchainImageBaseHeader*)&images[ 0 ] ) ) )
+		return {};
+
+	for ( const XrSwapchainImageD3D12KHR& image : images )
+	{
+		RefCntAutoPtr< ITexture > pTexture;
+		GetD3D12Device()->CreateTextureFromD3DResource( image.texture, RESOURCE_STATE_UNKNOWN, &pTexture );
+		textures.push_back( pTexture );
+	}
+
+	return textures;
+}
+
+#endif

--- a/src/graphicsbinding_d3d12.h
+++ b/src/graphicsbinding_d3d12.h
@@ -1,21 +1,20 @@
 #pragma once
 
-#if D3D11_SUPPORTED
 #include "igraphicsbinding.h"
 
-#include "Graphics/GraphicsEngineD3D11/interface/EngineFactoryD3D11.h"
+#include "Graphics/GraphicsEngineD3D12/interface/EngineFactoryD3D12.h"
 
 namespace Diligent
 {
-	struct IRenderDeviceD3D11;
+	struct IRenderDeviceD3D12;
 }
 
-struct XrGraphicsBindingD3D11KHR;
+struct XrGraphicsBindingD3D12KHR;
 
-class GraphicsBinding_D3D11 : public IGraphicsBinding
+class GraphicsBinding_D3D12 : public IGraphicsBinding
 {
 public:
-	virtual ~GraphicsBinding_D3D11();
+	virtual ~GraphicsBinding_D3D12();
 
 	virtual std::vector<std::string> GetXrExtensions() override;
 	virtual XrResult CreateDevice( XrInstance instance, XrSystemId systemId ) override;
@@ -29,20 +28,14 @@ public:
 
 
 private:
-	Diligent::IRenderDeviceD3D11* GetD3D11Device() { return (Diligent::IRenderDeviceD3D11*)GetRenderDevice(); }
+	Diligent::IRenderDeviceD3D12* GetD3D12Device() { return (Diligent::IRenderDeviceD3D12*)GetRenderDevice(); }
 
-	Diligent::RefCntAutoPtr<Diligent::IEngineFactoryD3D11>         m_pEngineFactory;
+	Diligent::RefCntAutoPtr<Diligent::IEngineFactoryD3D12>         m_pEngineFactory;
 	Diligent::RefCntAutoPtr<Diligent::IRenderDevice>  m_pDevice;
 	Diligent::RefCntAutoPtr<Diligent::IDeviceContext> m_pImmediateContext;
 
 	XrInstance m_instance = XR_NULL_HANDLE;
 	XrSystemId m_systemId;
 
-	XrGraphicsBindingD3D11KHR *m_d3d11Binding = nullptr;
+	XrGraphicsBindingD3D12KHR *m_d3d12Binding = nullptr;
 };
-#endif
-
-#if D3D11_SUPPORTED || D3D12_SUPPORTED
-#include <dxgi.h>
-UINT GetAdapterIndexFromLuid( LUID adapterId );
-#endif

--- a/src/helloxr.cpp
+++ b/src/helloxr.cpp
@@ -166,7 +166,10 @@ public:
 
 	~HelloXrApp()
 	{
-		m_pGraphicsBinding->GetImmediateContext()->Flush();
+		if (m_pGraphicsBinding)
+		{
+			m_pGraphicsBinding->GetImmediateContext()->Flush();
+		}
 	}
 
 	bool Initialize(HWND hWnd)
@@ -205,37 +208,19 @@ public:
 			}
 			break;
 #endif
+#if D3D12_SUPPORTED
+			case RENDER_DEVICE_TYPE_D3D12:
+			{
+#	if ENGINE_DLL
+				// Load the dll and import GetEngineFactoryD3D11() function
+				auto* GetEngineFactoryD3D12 = LoadGraphicsEngineD3D12();
+#	endif
+				auto* pFactoryD3D12 = GetEngineFactoryD3D12();
+				pFactoryD3D12->CreateSwapChainD3D12( m_pGraphicsBinding->GetRenderDevice(), m_pGraphicsBinding->GetImmediateContext(), SCDesc, FullScreenModeDesc {}, Window, &m_pSwapChain );
+			}
+			break;
+#endif
 
-//
-//#if D3D12_SUPPORTED
-//			case RENDER_DEVICE_TYPE_D3D12:
-//			{
-//				FETCH_AND_DEFINE_XR_FUNCTION( m_instance, xrGetD3D12GraphicsRequirementsKHR );
-//				XrGraphicsRequirementsD3D12KHR graphicsRequirements = { XR_TYPE_GRAPHICS_REQUIREMENTS_D3D12_KHR };
-//				XrResult res = xrGetD3D12GraphicsRequirementsKHR( m_instance, m_systemId, &graphicsRequirements );
-//				if ( XR_FAILED( res ) )
-//				{
-//					return false;
-//				}
-//
-//#	if ENGINE_DLL
-//				// Load the dll and import GetEngineFactoryD3D12() function
-//				auto GetEngineFactoryD3D12 = LoadGraphicsEngineD3D12();
-//#	endif
-//				EngineD3D12CreateInfo EngineCI;
-//				EngineCI.AdapterId = GetAdapterIndexFromLuid( graphicsRequirements.adapterLuid );
-//				EngineCI.GraphicsAPIVersion = Version { 12, 0 };
-//
-//				auto* pFactoryD3D12 = GetEngineFactoryD3D12();
-//				m_pEngineFactory = pFactoryD3D12;
-//				pFactoryD3D12->CreateDeviceAndContextsD3D12(EngineCI, &m_pGraphicsBinding->GetRenderDevice(), &m_pGraphicsBinding->GetImmediateContext());
-//				Win32NativeWindow Window{hWnd};
-//				pFactoryD3D12->CreateSwapChainD3D12(m_pGraphicsBinding->GetRenderDevice(), m_pGraphicsBinding->GetImmediateContext(), SCDesc, FullScreenModeDesc{}, Window, &m_pSwapChain);
-//			}
-//			break;
-//#endif
-//
-//
 //#if GL_SUPPORTED
 //			case RENDER_DEVICE_TYPE_GL:
 //			{

--- a/src/igraphicsbinding.cpp
+++ b/src/igraphicsbinding.cpp
@@ -1,6 +1,7 @@
 #include "igraphicsbinding.h"
 
 #include "graphicsbinding_d3d11.h"
+#include "graphicsbinding_d3d12.h"
 
 using namespace Diligent;
 
@@ -11,6 +12,10 @@ std::unique_ptr<IGraphicsBinding> IGraphicsBinding::CreateBindingForDeviceType( 
 	{
 	case RENDER_DEVICE_TYPE_D3D11:
 		binding = std::make_unique<GraphicsBinding_D3D11>();
+		break;
+
+	case RENDER_DEVICE_TYPE_D3D12:
+		binding = std::make_unique<GraphicsBinding_D3D12>();
 		break;
 
 	default:


### PR DESCRIPTION
* Makes GetAdapterIndexFromLuid accessible from D3D12 binding and conditionally builds for 11 or 12.
* D3D12 binding is basically identically to the D3D11 binding except for the need to access the command queue (by unlocking and then relocking since Diligent protects it).
* Fixed crashes that could happen on "delete" if something went wrong on startup and the pointer was never set to something heap allocated.